### PR TITLE
Adding support to shared tables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'pendulum>=1.2.0<2.0.0',
         'singer-python>=5.12.2<6.0.0',
         'backoff>=1.3.2<2.0.0',
-        'psycopg2>=2.9.3<3.0.0',
+        'psycopg2-binary>=2.9.3<2.9.5',
       ],
       setup_requires=[
         'pytest-runner>=2.11,<3.0a',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'pendulum>=1.2.0<2.0.0',
         'singer-python>=5.12.2<6.0.0',
         'backoff>=1.3.2<2.0.0',
-        'psycopg2-binary>=2.9.3<2.9.5',
+        'psycopg2-binary>=2.9.3<3.0.0',
       ],
       setup_requires=[
         'pytest-runner>=2.11,<3.0a',

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -72,33 +72,33 @@ DATETIME_TYPES = {'timestamp', 'timestamptz',
 CONFIG = {}
 
 
-def discover_catalog(conn, db_schema):
-    '''Returns a Catalog describing the structure of the database.'''
+def discover_catalog(conn, db_name, db_schema):
+    """Returns a Catalog describing the structure of the database."""
 
     table_spec = select_all(
         conn,
-        """
+        f"""
         SELECT table_name, table_type
         FROM SVV_ALL_TABLES
-        WHERE schema_name = '{}'
-        """.format(db_schema))
+        WHERE schema_name = '{db_schema}' and database_name = '{db_name}'
+        """)
 
     column_specs = select_all(
         conn,
-        """
+        f"""
         SELECT c.table_name, c.ordinal_position, c.column_name, c.data_type,
         c.is_nullable
         FROM SVV_ALL_TABLES t
         JOIN SVV_ALL_COLUMNS c
             ON c.table_name = t.table_name AND
                c.schema_name = t.schema_name
-        WHERE t.schema_name = '{}'
+        WHERE t.schema_name = '{db_schema}' and t.database_name = '{db_name}'
         ORDER BY c.table_name, c.ordinal_position
-        """.format(db_schema))
+        """)
 
     pk_specs = select_all(
         conn,
-        """
+        f"""
         SELECT kc.table_name, kc.column_name
         FROM information_schema.table_constraints tc
         JOIN information_schema.key_column_usage kc
@@ -106,12 +106,12 @@ def discover_catalog(conn, db_schema):
                kc.table_schema = tc.table_schema AND
                kc.constraint_name = tc.constraint_name
         WHERE tc.constraint_type = 'PRIMARY KEY' AND
-              tc.table_schema = '{}'
+              tc.table_schema = '{db_schema}'
         ORDER BY
           tc.table_schema,
           tc.table_name,
           kc.ordinal_position
-        """.format(db_schema))
+        """)
 
     entries = []
     table_columns = [{'name': k, 'columns': [
@@ -153,14 +153,14 @@ def discover_catalog(conn, db_schema):
     return Catalog(entries)
 
 
-def do_discover(conn, db_schema):
+def do_discover(conn, db_name, db_schema):
     LOGGER.info("Running discover")
-    discover_catalog(conn, db_schema).dump()
+    discover_catalog(conn, db_name, db_schema).dump()
     LOGGER.info("Completed discover")
 
 
 def schema_for_column(c):
-    '''Returns the Schema object for the given Column.'''
+    """Returns the Schema object for the given Column."""
     column_type = c['type'].lower()
     column_nullable = c['nullable'].lower()
     inclusion = 'available'
@@ -404,8 +404,8 @@ def sync_table(connection, catalog_entry, state):
         yield singer.StateMessage(value=copy.deepcopy(state))
 
 
-def generate_messages(conn, db_schema, catalog, state):
-    catalog = resolve.resolve_catalog(discover_catalog(conn, db_schema),
+def generate_messages(conn, db_name, db_schema, catalog, state):
+    catalog = resolve.resolve_catalog(discover_catalog(conn, db_name, db_schema),
                                       catalog, state)
 
     for catalog_entry in catalog.streams:
@@ -448,9 +448,9 @@ def coerce_datetime(o):
     raise TypeError("Type {} is not serializable".format(type(o)))
 
 
-def do_sync(conn, db_schema, catalog, state):
+def do_sync(conn, db_name, db_schema, catalog, state):
     LOGGER.info("Starting Redshift sync")
-    for message in generate_messages(conn, db_schema, catalog, state):
+    for message in generate_messages(conn, db_name, db_schema, catalog, state):
         sys.stdout.write(json.dumps(message.asdict(),
                          default=coerce_datetime,
                          use_decimal=True) + '\n')
@@ -513,15 +513,16 @@ def main_impl():
     CONFIG.update(args.config)
     connection = open_connection(args.config)
     db_schema = args.config.get('schema', 'public')
+    db_name = args.config.get('dbname', 'dev')
     if args.discover:
-        do_discover(connection, db_schema)
+        do_discover(connection, db_name, db_schema)
     elif args.catalog:
         state = build_state(args.state, args.catalog)
-        do_sync(connection, db_schema, args.catalog, state)
+        do_sync(connection, db_name, db_schema, args.catalog, state)
     elif args.properties:
         catalog = Catalog.from_dict(args.properties)
         state = build_state(args.state, catalog)
-        do_sync(connection, db_schema, catalog, state)
+        do_sync(connection, db_name, db_schema, catalog, state)
     else:
         LOGGER.info("No properties were selected")
 

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -124,6 +124,8 @@ def discover_catalog(conn, db_name, db_schema):
 
     table_types = dict(table_spec)
 
+    LOGGER.INFO(table_columns)
+
     for items in table_columns:
         table_name = items['name']
         qualified_table_name = '{}.{}'.format(db_schema, table_name)

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -54,12 +54,15 @@ STRING_TYPES = {'char', 'character', 'nchar', 'bpchar', 'text', 'varchar',
 
 BYTES_FOR_INTEGER_TYPE = {
     'int2': 2,
+    'smallint': 2,
     'int': 4,
     'int4': 4,
-    'int8': 8
+    'integer': 4,
+    'int8': 8,
+    'bigint': 8
 }
 
-FLOAT_TYPES = {'float', 'float4', 'float8'}
+FLOAT_TYPES = {'float', 'float4', 'float8', 'double precision', 'real'}
 
 DATE_TYPES = {'date'}
 
@@ -164,7 +167,7 @@ def schema_for_column(c):
     inclusion = 'available'
     result = Schema(inclusion=inclusion)
 
-    if column_type == 'bool':
+    if column_type in ('bool', 'boolean'):
         result.type = 'boolean'
 
     elif column_type in BYTES_FOR_INTEGER_TYPE:

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -124,7 +124,10 @@ def discover_catalog(conn, db_name, db_schema):
 
     table_types = dict(table_spec)
 
-    LOGGER.info(table_columns)
+    LOGGER.info(f"""Spec query: SELECT table_name, table_type
+        FROM SVV_ALL_TABLES
+        WHERE schema_name = '{db_schema}' and database_name = '{db_name}'""")
+    LOGGER.info(f'Table Spec: {table_spec}')
 
     for items in table_columns:
         table_name = items['name']

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -76,20 +76,20 @@ def discover_catalog(conn, db_schema):
         conn,
         """
         SELECT table_name, table_type
-        FROM INFORMATION_SCHEMA.Tables
-        WHERE table_schema = '{}'
+        FROM SVV_ALL_TABLES
+        WHERE schema_name = '{}'
         """.format(db_schema))
 
     column_specs = select_all(
         conn,
         """
-        SELECT c.table_name, c.ordinal_position, c.column_name, c.udt_name,
+        SELECT c.table_name, c.ordinal_position, c.column_name, c.data_type,
         c.is_nullable
-        FROM INFORMATION_SCHEMA.Tables t
-        JOIN INFORMATION_SCHEMA.Columns c
+        FROM SVV_ALL_TABLES t
+        JOIN SVV_ALL_COLUMNS c
             ON c.table_name = t.table_name AND
-               c.table_schema = t.table_schema
-        WHERE t.table_schema = '{}'
+               c.schema_name = t.schema_name
+        WHERE t.schema_name = '{}'
         ORDER BY c.table_name, c.ordinal_position
         """.format(db_schema))
 
@@ -156,6 +156,7 @@ def do_discover(conn, db_schema):
     LOGGER.info("Completed discover")
 
 
+# TODO: need to review after adding changing the columns table
 def schema_for_column(c):
     '''Returns the Schema object for the given Column.'''
     column_type = c['type'].lower()

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -18,6 +18,7 @@
 # data.world, Inc.(http://data.world/).
 
 import copy
+import logging
 import time
 from itertools import groupby
 
@@ -123,6 +124,8 @@ def discover_catalog(conn, db_name, db_schema):
                  for k, v in groupby(pk_specs, key=lambda t: t[0])}
 
     table_types = dict(table_spec)
+
+    logging.INFO(table_columns)
 
     for items in table_columns:
         table_name = items['name']

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -159,7 +159,6 @@ def do_discover(conn, db_schema):
     LOGGER.info("Completed discover")
 
 
-# TODO: need to review after adding changing the columns table
 def schema_for_column(c):
     '''Returns the Schema object for the given Column.'''
     column_type = c['type'].lower()

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -124,11 +124,6 @@ def discover_catalog(conn, db_name, db_schema):
 
     table_types = dict(table_spec)
 
-    LOGGER.info(f"""Spec query: SELECT table_name, table_type
-        FROM SVV_ALL_TABLES
-        WHERE schema_name = '{db_schema}' and database_name = '{db_name}'""")
-    LOGGER.info(f'Table Spec: {table_spec}')
-
     for items in table_columns:
         table_name = items['name']
         qualified_table_name = '{}.{}'.format(db_schema, table_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,7 @@ def column_specs_cursor():
 def expected_catalog_from_db():
     return Catalog.from_dict({'streams': [
         {'tap_stream_id': 'test-db.public.table1',
+         'database_name': 'test-db',
          'table_name': 'public.table1',
          'schema': {
              'properties': {
@@ -139,6 +140,7 @@ def expected_catalog_from_db():
                            'inclusion': 'available'}}
          ]},
         {'tap_stream_id': 'test-db.public.table2',
+         'database_name': 'test-db',
          'table_name': 'public.table2',
          'schema': {
              'properties': {
@@ -173,6 +175,7 @@ def expected_catalog_from_db():
                            'sql-datatype': 'bool',
                            'inclusion': 'available'}}]},
         {'tap_stream_id': 'test-db.public.view1',
+         'database_name': 'test-db',
          'table_name': 'public.view1',
          'schema': {
              'properties': {

--- a/tests/tap_redshift/test_tap_redshift.py
+++ b/tests/tap_redshift/test_tap_redshift.py
@@ -201,8 +201,7 @@ expected_result = {
 
 class TestRedShiftTap(object):
     def test_discover_catalog(self, discovery_conn, expected_catalog_from_db):
-        actual_catalog = tap_redshift.discover_catalog(discovery_conn,
-                                                       'public')
+        actual_catalog = tap_redshift.discover_catalog(discovery_conn, 'test-db', 'public')
         for i, actual_entry in enumerate(actual_catalog.streams):
 
             expected_entry = expected_catalog_from_db.streams[i]
@@ -309,8 +308,7 @@ class TestRedShiftTap(object):
         assert_that(column_schema, equal_to(expected_schema))
 
     def test_table_metadata(self, discovery_conn, expected_catalog_from_db):
-        actual_catalog = tap_redshift.discover_catalog(discovery_conn,
-                                                       'public')
+        actual_catalog = tap_redshift.discover_catalog(discovery_conn, 'test-db', 'public')
         for i, actual_entry in enumerate(actual_catalog.streams):
             expected_entry = expected_catalog_from_db.streams[i]
             actual_metadata = metadata.to_map(actual_entry.metadata)


### PR DESCRIPTION
The Redshift extractor works by first discovering what tables and views are available to sync. This is done by querying information_schema to get table names, columns, etc. However, metadata on shared table views are not available so the extractor fails. Additionally, shared database is set up in its own database on Redshift and we cannot connect to it directly.

```
Cannot connect to shared database "...". Connect to the databases in your cluster instead and use cross-database query notation .
```

So in this PR we are replacing the `INFORMATION_SCHEMA.Tables` by `SVV_ALL_TABLES` and replacing `INFORMATION_SCHEMA.Columns` by `SVV_ALL_COLUMNS` that shows shared tables information.

The only limitation that we still have is that we still didn't get the table constraints/PKs for shared tables.