### PR TITLE
Support external redshift tables and multiple schemas

### DIFF
--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -77,6 +77,7 @@ ROWS_PER_NETWORK_CALL = 40_000
 
 def discover_catalog(conn, db_name, db_schema):
     '''Returns a Catalog describing the structure of the database.'''
+    db_schema = tuple(db_schema)
 
     table_spec = select_all(
         conn,
@@ -95,7 +96,7 @@ def discover_catalog(conn, db_name, db_schema):
             FROM SVV_ALL_TABLES t
             JOIN SVV_ALL_COLUMNS c
             ON c.table_name = t.table_name AND c.schema_name = t.schema_name
-            WHERE t.schema_name in '{db_schema}' and t.database_name = '{db_name}'
+            WHERE t.schema_name in '{tuple(db_schema)}' and t.database_name = '{db_name}'
             ORDER BY c.table_name, c.ordinal_position
         """
     )

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -55,12 +55,15 @@ STRING_TYPES = {'char', 'character', 'nchar', 'bpchar', 'text', 'varchar',
 
 BYTES_FOR_INTEGER_TYPE = {
     'int2': 2,
+    'smallint': 2,
     'int': 4,
     'int4': 4,
-    'int8': 8
+    'integer': 4,
+    'int8': 8,
+    'bigint': 8
 }
 
-FLOAT_TYPES = {'float', 'float4', 'float8'}
+FLOAT_TYPES = {'float', 'float4', 'float8', 'double precision', 'real'}
 
 DATE_TYPES = {'date'}
 

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -138,11 +138,9 @@ def discover_catalog(conn, db_name, db_schemas):
         """
     )
     entries = []
-    LOGGER.warning(f"column_specs before transformation: {column_specs}")
     table_columns = [{'name': k, 'columns': [
         {'pos': t[1], 'name': t[2], 'type': t[3], 'nullable': t[4], } for t in v
     ]} for k, v in groupby(column_specs, key=lambda t: t[0])]
-    LOGGER.warning(f"Table_columns after transformation: {table_columns}")
     table_pks = {k: [t[1] for t in v]
                  for k, v in groupby(pk_specs, key=lambda t: t[0])}
     table_spec_dict = table_spec_to_dict(table_spec)

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -94,6 +94,7 @@ def transform_db_schema_type(db_schemas):
         else:
             return f"('{db_schemas[0]}')"
 
+
 def discover_catalog(conn, db_name, db_schemas):
     '''Returns a Catalog describing the structure of the database.'''
     db_schemas = transform_db_schema_type(db_schemas)
@@ -137,11 +138,11 @@ def discover_catalog(conn, db_name, db_schemas):
         """
     )
     entries = []
+    LOGGER.warning(f"column_specs before transformation: {column_specs}")
     table_columns = [{'name': k, 'columns': [
-        {'pos': t[1], 'name': t[2], 'type': t[3],
-         'nullable': t[4]} for t in v]}
-                     for k, v in groupby(column_specs, key=lambda t: t[0])]
-
+        {'pos': t[1], 'name': t[2], 'nullable': t[3], 'type': t[4]} for t in v
+    ]} for k, v in groupby(column_specs, key=lambda t: t[0])]
+    LOGGER.warning(f"Table_columns after transformation: {table_columns}")
     table_pks = {k: [t[1] for t in v]
                  for k, v in groupby(pk_specs, key=lambda t: t[0])}
     table_spec_dict = table_spec_to_dict(table_spec)

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -76,6 +76,7 @@ ROWS_PER_NETWORK_CALL = 40_000
 
 
 def table_spec_to_dict(table_spec):
+    """Converts table_spec results to a dictionary with table names as keys."""
     table_spec_dict = {}
     for table in table_spec:
         table_spec_dict[table[0]] = {'table_type': table[1], 'table_schema': table[2]}
@@ -84,6 +85,7 @@ def table_spec_to_dict(table_spec):
 
 
 def transform_db_schema_type(db_schemas):
+    """Converts db_schemas for querying."""
     if type(db_schemas) == str:
         return f"('{db_schemas}')"
     elif type(db_schemas) == list:

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -79,12 +79,23 @@ def table_spec_to_dict(table_spec):
     table_spec_dict = {}
     for table in table_spec:
         table_spec_dict[table[0]] = {'table_type': table[1], 'table_schema': table[2]}
+    LOGGER.info(f"table_spec_dict: {table_spec_dict}")
     return table_spec_dict
+
+
+def transform_db_schema_type(db_schemas):
+    if type(db_schemas) == str:
+        return f"('{db_schemas}')"
+    elif type(db_schemas) == list:
+        if len(db_schemas) >= 2:
+            return tuple(db_schemas)
+        else:
+            return f"('{db_schemas[0]}')"
 
 
 def discover_catalog(conn, db_name, db_schemas):
     '''Returns a Catalog describing the structure of the database.'''
-    db_schemas = tuple(db_schemas)
+    db_schemas = transform_db_schema_type(db_schemas)
     table_spec = select_all(
         conn,
         f"""
@@ -133,7 +144,6 @@ def discover_catalog(conn, db_name, db_schemas):
     table_pks = {k: [t[1] for t in v]
                  for k, v in groupby(pk_specs, key=lambda t: t[0])}
     table_spec_dict = table_spec_to_dict(table_spec)
-    LOGGER.warning(f"TABLE_SPEC_DICT: {table_spec_dict}")
 
     for items in table_columns:
         table_name = items['name']

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -77,14 +77,13 @@ ROWS_PER_NETWORK_CALL = 40_000
 
 def discover_catalog(conn, db_name, db_schema):
     '''Returns a Catalog describing the structure of the database.'''
-    db_schema = tuple(db_schema)
 
     table_spec = select_all(
         conn,
         f"""
         SELECT table_name, table_type
         FROM SVV_ALL_TABLES
-        WHERE schema_name in '{db_schema}' and database_name = '{db_name}'
+        WHERE schema_name = '{db_schema}' and database_name = '{db_name}'
         """
     )
     LOGGER.info(f"TABLE_SPEC: {table_spec}")
@@ -96,7 +95,7 @@ def discover_catalog(conn, db_name, db_schema):
             FROM SVV_ALL_TABLES t
             JOIN SVV_ALL_COLUMNS c
             ON c.table_name = t.table_name AND c.schema_name = t.schema_name
-            WHERE t.schema_name in '{tuple(db_schema)}' and t.database_name = '{db_name}'
+            WHERE t.schema_name = '{db_schema}' and t.database_name = '{db_name}'
             ORDER BY c.table_name, c.ordinal_position
         """
     )
@@ -111,7 +110,7 @@ def discover_catalog(conn, db_name, db_schema):
                kc.table_schema = tc.table_schema AND
                kc.constraint_name = tc.constraint_name
         WHERE tc.constraint_type = 'PRIMARY KEY' AND
-        tc.table_schema in '{db_schema}'
+        tc.table_schema = '{db_schema}'
         ORDER BY
           tc.table_schema,
           tc.table_name,

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -77,7 +77,6 @@ ROWS_PER_NETWORK_CALL = 40_000
 
 def discover_catalog(conn, db_name, db_schema):
     '''Returns a Catalog describing the structure of the database.'''
-
     table_spec = select_all(
         conn,
         f"""

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -145,11 +145,12 @@ def discover_catalog(conn, db_name, db_schemas):
         """
     )
     entries = []
+    LOGGER.warning(f"RAW COLUMN SPECS: {column_specs}")
     table_columns = [{'name': k, 'columns': [
         {'pos': t[1], 'name': t[2], 'type': t[3],
          'nullable': handle_external_nullable_column(t[4])} for t in v]}
                      for k, v in groupby(column_specs, key=lambda t: t[0])]
-
+    LOGGER.warning(f"FORMATTED TABLE COLUMNS: {table_columns}")
     table_pks = {k: [t[1] for t in v]
                  for k, v in groupby(pk_specs, key=lambda t: t[0])}
     table_spec_dict = table_spec_to_dict(table_spec)

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -90,7 +90,7 @@ def discover_catalog(conn, db_schema):
         WHERE schemaname = 'data_catalog'
         """
     )
-
+    LOGGER.info(f"TABLE_SPEC: {table_spec}")
     column_specs = select_all(
         conn,
         """

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -140,7 +140,7 @@ def discover_catalog(conn, db_name, db_schemas):
     entries = []
     LOGGER.warning(f"column_specs before transformation: {column_specs}")
     table_columns = [{'name': k, 'columns': [
-        {'pos': t[1], 'name': t[2], 'nullable': t[3], 'type': t[4]} for t in v
+        {'pos': t[1], 'name': t[2], 'type': t[3], 'nullable': t[4], } for t in v
     ]} for k, v in groupby(column_specs, key=lambda t: t[0])]
     LOGGER.warning(f"Table_columns after transformation: {table_columns}")
     table_pks = {k: [t[1] for t in v]

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -106,7 +106,7 @@ def discover_catalog(conn, db_name, db_schemas):
         WHERE schema_name in {db_schemas} and database_name = '{db_name}'
         """
     )
-    LOGGER.info(f"TABLE_SPEC: {table_spec}")
+
     column_specs = select_all(
         conn,
         f"""

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -96,9 +96,10 @@ def transform_db_schema_type(db_schemas):
 
 
 def handle_external_nullable_column(column):
-    if column[4] not in [True, False]:
+    """If the column does not contain True or False default to True."""
+    if column not in [True, False]:
         return True
-    return column[4]
+    return column
 
 
 def discover_catalog(conn, db_name, db_schemas):

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -90,7 +90,7 @@ def discover_catalog(conn, db_name, db_schema):
     column_specs = select_all(
         conn,
         f"""
-            SELECT c.table_name, c.ordinal_position, c.column_name, c.data_type,
+            SELECT DISTINCT c.table_name, c.ordinal_position, c.column_name, c.data_type,
             c.is_nullable
             FROM SVV_ALL_TABLES t
             JOIN SVV_ALL_COLUMNS c

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -125,8 +125,9 @@ def discover_catalog(conn, db_name, db_schemas):
 
     table_pks = {k: [t[1] for t in v]
                  for k, v in groupby(pk_specs, key=lambda t: t[0])}
-
-    table_types = dict(table_spec)
+    LOGGER.warning(f"TABLE_SPEC:{table_spec}")
+    LOGGER.warning(f"TABLE_SPEC TYPE: {type(table_spec)}")
+    table_types = dict(table_spec[0:1])
     LOGGER.warning(f"TABLE_TYPES: {table_types}")
 
     for items in table_columns:

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -91,7 +91,7 @@ def discover_catalog(conn, db_name, db_schema):
             c.is_nullable
             FROM SVV_ALL_TABLES t
             JOIN SVV_ALL_COLUMNS c
-            c.schema_name = t.schema_name
+            ON c.table_name = t.table_name AND c.schema_name = t.schema_name
             WHERE t.schema_name = '{db_schema}' and t.database_name = '{db_name}'
             ORDER BY c.table_name, c.ordinal_position
         """

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -83,7 +83,7 @@ def discover_catalog(conn, db_name, db_schema):
         f"""
         SELECT table_name, table_type
         FROM SVV_ALL_TABLES
-        WHERE schema_name in ('{db_schema}', 'data_catalog) and database_name = '{db_name}'
+        WHERE schema_name in '{db_schema}' and database_name = '{db_name}'
         """
     )
     LOGGER.info(f"TABLE_SPEC: {table_spec}")
@@ -95,7 +95,7 @@ def discover_catalog(conn, db_name, db_schema):
             FROM SVV_ALL_TABLES t
             JOIN SVV_ALL_COLUMNS c
             ON c.table_name = t.table_name AND c.schema_name = t.schema_name
-            WHERE t.schema_name in ('{db_schema}', 'data_catalog) and t.database_name = '{db_name}'
+            WHERE t.schema_name in '{db_schema}' and t.database_name = '{db_name}'
             ORDER BY c.table_name, c.ordinal_position
         """
     )
@@ -110,7 +110,7 @@ def discover_catalog(conn, db_name, db_schema):
                kc.table_schema = tc.table_schema AND
                kc.constraint_name = tc.constraint_name
         WHERE tc.constraint_type = 'PRIMARY KEY' AND
-        tc.table_schema in ('{db_schema}', 'data_catalog)
+        tc.table_schema in '{db_schema}'
         ORDER BY
           tc.table_schema,
           tc.table_name,

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -83,7 +83,7 @@ def discover_catalog(conn, db_name, db_schema):
         f"""
         SELECT table_name, table_type
         FROM SVV_ALL_TABLES
-        WHERE schema_name = '{db_schema}' and database_name = '{db_name}'
+        WHERE schema_name in ('{db_schema}', 'data_catalog) and database_name = '{db_name}'
         """
     )
     LOGGER.info(f"TABLE_SPEC: {table_spec}")
@@ -95,7 +95,7 @@ def discover_catalog(conn, db_name, db_schema):
             FROM SVV_ALL_TABLES t
             JOIN SVV_ALL_COLUMNS c
             ON c.table_name = t.table_name AND c.schema_name = t.schema_name
-            WHERE t.schema_name = '{db_schema}' and t.database_name = '{db_name}'
+            WHERE t.schema_name in ('{db_schema}', 'data_catalog) and t.database_name = '{db_name}'
             ORDER BY c.table_name, c.ordinal_position
         """
     )
@@ -110,7 +110,7 @@ def discover_catalog(conn, db_name, db_schema):
                kc.table_schema = tc.table_schema AND
                kc.constraint_name = tc.constraint_name
         WHERE tc.constraint_type = 'PRIMARY KEY' AND
-        tc.table_schema = '{db_schema}'
+        tc.table_schema in ('{db_schema}', 'data_catalog)
         ORDER BY
           tc.table_schema,
           tc.table_name,

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -86,7 +86,7 @@ def discover_catalog(conn, db_schema):
     table_spec += select_all(
         conn,
         """
-        SELECT tablename as table_name, tabletype as table_type FROM SVV_EXTERNAL_TABLES
+        SELECT tablename as table_name, 'BASE TABLE' as table_type FROM SVV_EXTERNAL_TABLES
         WHERE schemaname = 'data_catalog'
         """
     )

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -82,6 +82,14 @@ def discover_catalog(conn, db_schema):
         FROM INFORMATION_SCHEMA.Tables
         WHERE table_schema = '{}'
         """.format(db_schema))
+    # Include data catalog tables in validation.
+    table_spec += select_all(
+        conn,
+        """
+        SELECT tablename as table_name, tabletype as table_type FROM SVV_EXTERNAL_TABLES
+        WHERE schemaname = 'data_catalog'
+        """
+    )
 
     column_specs = select_all(
         conn,

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -95,6 +95,12 @@ def transform_db_schema_type(db_schemas):
             return f"('{db_schemas[0]}')"
 
 
+def handle_external_nullable_column(column):
+    if column[4] not in [True, False]:
+        return True
+    return column[4]
+
+
 def discover_catalog(conn, db_name, db_schemas):
     '''Returns a Catalog describing the structure of the database.'''
     db_schemas = transform_db_schema_type(db_schemas)
@@ -140,7 +146,7 @@ def discover_catalog(conn, db_name, db_schemas):
     entries = []
     table_columns = [{'name': k, 'columns': [
         {'pos': t[1], 'name': t[2], 'type': t[3],
-         'nullable': t[4]} for t in v]}
+         'nullable': handle_external_nullable_column(t[4])} for t in v]}
                      for k, v in groupby(column_specs, key=lambda t: t[0])]
 
     table_pks = {k: [t[1] for t in v]

--- a/tap_redshift/resolve.py
+++ b/tap_redshift/resolve.py
@@ -86,7 +86,9 @@ def get_selected_properties(catalog_entry):
 
 
 def resolve_catalog(discovered, catalog, state):
+    LOGGER.warning(f"STREAMS BEFORE FILTER{catalog.streams}")
     streams = list(filter(entry_is_selected, catalog.streams))
+    LOGGER.warning(f"STREAMS AFTER FILTER{streams}")
 
     currently_syncing = singer.get_currently_syncing(state)
     if currently_syncing:

--- a/tap_redshift/resolve.py
+++ b/tap_redshift/resolve.py
@@ -67,8 +67,8 @@ def desired_columns(selected, table_schema):
 
 def entry_is_selected(catalog_entry):
     mdata = metadata.new()
-    LOGGER.WARNING(f"CATALOG.METADATA FOR {catalog_entry.tap_stream_id}: {catalog_entry.metadata}")
-    LOGGER.WARNING(f"BOOL RESOLUTION: {bool(catalog_entry.is_selected() or metadata.get(mdata, (), 'selected'))}")
+    LOGGER.warning(f"CATALOG.METADATA FOR {catalog_entry.tap_stream_id}: {catalog_entry.metadata}")
+    LOGGER.warning(f"BOOL RESOLUTION: {bool(catalog_entry.is_selected() or metadata.get(mdata, (), 'selected'))}")
     if catalog_entry.metadata is not None:
         mdata = metadata.to_map(catalog_entry.metadata)
     return bool(catalog_entry.is_selected()
@@ -90,9 +90,9 @@ def get_selected_properties(catalog_entry):
 def resolve_catalog(discovered, catalog, state):
     LOGGER.warning(f"DISCOVERED: {discovered}")
     LOGGER.warning(f"CATALOG: {catalog}")
-    LOGGER.WARNING(f"STREAMS BEFORE FILTER: {catalog.streams}")
+    LOGGER.warning(f"STREAMS BEFORE FILTER: {catalog.streams}")
     streams = list(filter(entry_is_selected, catalog.streams))
-    LOGGER.WARNING(f"STREAMS AFTER FILTER: {streams}")
+    LOGGER.warning(f"STREAMS AFTER FILTER: {streams}")
 
     currently_syncing = singer.get_currently_syncing(state)
     if currently_syncing:

--- a/tap_redshift/resolve.py
+++ b/tap_redshift/resolve.py
@@ -67,6 +67,8 @@ def desired_columns(selected, table_schema):
 
 def entry_is_selected(catalog_entry):
     mdata = metadata.new()
+    LOGGER.WARNING(f"CATALOG.METADATA FOR {catalog_entry.tap_stream_id}: {catalog_entry.metadata}")
+    LOGGER.WARNING(f"BOOL RESOLUTION: {bool(catalog_entry.is_selected() or metadata.get(mdata, (), 'selected'))}")
     if catalog_entry.metadata is not None:
         mdata = metadata.to_map(catalog_entry.metadata)
     return bool(catalog_entry.is_selected()
@@ -86,7 +88,11 @@ def get_selected_properties(catalog_entry):
 
 
 def resolve_catalog(discovered, catalog, state):
+    LOGGER.warning(f"DISCOVERED: {discovered}")
+    LOGGER.warning(f"CATALOG: {catalog}")
+    LOGGER.WARNING(f"STREAMS BEFORE FILTER: {catalog.streams}")
     streams = list(filter(entry_is_selected, catalog.streams))
+    LOGGER.WARNING(f"STREAMS AFTER FILTER: {streams}")
 
     currently_syncing = singer.get_currently_syncing(state)
     if currently_syncing:

--- a/tap_redshift/resolve.py
+++ b/tap_redshift/resolve.py
@@ -88,11 +88,7 @@ def get_selected_properties(catalog_entry):
 
 
 def resolve_catalog(discovered, catalog, state):
-    LOGGER.warning(f"DISCOVERED: {discovered}")
-    LOGGER.warning(f"CATALOG: {catalog}")
-    LOGGER.warning(f"STREAMS BEFORE FILTER: {catalog.streams}")
     streams = list(filter(entry_is_selected, catalog.streams))
-    LOGGER.warning(f"STREAMS AFTER FILTER: {streams}")
 
     currently_syncing = singer.get_currently_syncing(state)
     if currently_syncing:
@@ -104,9 +100,7 @@ def resolve_catalog(discovered, catalog, state):
     # Iterate over the streams in the input catalog and match each one up
     # with the same stream in the discovered catalog.
     for catalog_entry in streams:
-        LOGGER.warning(f"catalog_entry: {catalog_entry.tap_stream_id}")
         discovered_table = discovered.get_stream(catalog_entry.tap_stream_id)
-        LOGGER.warning(f"DISCONVEREDTABLES: {discovered_table}")
         if not discovered_table:
             LOGGER.warning('Database {} table {} selected but does not exist'
                            .format(catalog_entry.database,

--- a/tap_redshift/resolve.py
+++ b/tap_redshift/resolve.py
@@ -86,6 +86,7 @@ def get_selected_properties(catalog_entry):
 
 
 def resolve_catalog(discovered, catalog, state):
+    LOGGER.warning(f"DISCOVERED: {discovered}")
     LOGGER.warning(f"STREAMS BEFORE FILTER{catalog.streams}")
     streams = list(filter(entry_is_selected, catalog.streams))
     LOGGER.warning(f"STREAMS AFTER FILTER{streams}")

--- a/tap_redshift/resolve.py
+++ b/tap_redshift/resolve.py
@@ -86,10 +86,7 @@ def get_selected_properties(catalog_entry):
 
 
 def resolve_catalog(discovered, catalog, state):
-    LOGGER.warning(f"DISCOVERED: {discovered}")
-    LOGGER.warning(f"STREAMS BEFORE FILTER{catalog.streams}")
     streams = list(filter(entry_is_selected, catalog.streams))
-    LOGGER.warning(f"STREAMS AFTER FILTER{streams}")
 
     currently_syncing = singer.get_currently_syncing(state)
     if currently_syncing:
@@ -101,7 +98,9 @@ def resolve_catalog(discovered, catalog, state):
     # Iterate over the streams in the input catalog and match each one up
     # with the same stream in the discovered catalog.
     for catalog_entry in streams:
+        LOGGER.warning(f"catalog_entry: {catalog_entry.tap_stream_id}")
         discovered_table = discovered.get_stream(catalog_entry.tap_stream_id)
+        LOGGER.warning(f"DISCONVEREDTABLES: {discovered_table}")
         if not discovered_table:
             LOGGER.warning('Database {} table {} selected but does not exist'
                            .format(catalog_entry.database,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,7 @@ def column_specs_cursor():
 def expected_catalog_from_db():
     return Catalog.from_dict({'streams': [
         {'tap_stream_id': 'test-db.public.table1',
+         'database_name': 'test-db',
          'table_name': 'public.table1',
          'schema': {
              'properties': {
@@ -139,6 +140,7 @@ def expected_catalog_from_db():
                            'inclusion': 'available'}}
          ]},
         {'tap_stream_id': 'test-db.public.table2',
+         'database_name': 'test-db',
          'table_name': 'public.table2',
          'schema': {
              'properties': {
@@ -173,6 +175,7 @@ def expected_catalog_from_db():
                            'sql-datatype': 'bool',
                            'inclusion': 'available'}}]},
         {'tap_stream_id': 'test-db.public.view1',
+         'database_name': 'test-db',
          'table_name': 'public.view1',
          'schema': {
              'properties': {

--- a/tests/tap_redshift/test_tap_redshift.py
+++ b/tests/tap_redshift/test_tap_redshift.py
@@ -309,8 +309,9 @@ class TestRedShiftTap(object):
         assert_that(column_schema, equal_to(expected_schema))
 
     def test_table_metadata(self, discovery_conn, expected_catalog_from_db):
-        actual_catalog = tap_redshift.discover_catalog(discovery_conn,
-                                                       'public')
+        actual_catalog = tap_redshift.discover_catalog(
+            discovery_conn, 'test-db', 'public'
+        )
         for i, actual_entry in enumerate(actual_catalog.streams):
             expected_entry = expected_catalog_from_db.streams[i]
             actual_metadata = metadata.to_map(actual_entry.metadata)


### PR DESCRIPTION
I have implemented the capability to include externally shared Redshift tables, which were previously excluded from the existing queries. Moreover, the tap now supports multiple schemas and can correctly identify the appropriate table and schema combination passed via the catalogs.

Unfortunately, it does not currently look possible to retrieve column constraints for externally shared tables. Consequently, to ensure compatibility with our targets that depend on nullable field entries, I have set all columns of externally shared tables to be nullable by default since the column_specs query does not populate the "is_nullable" field for these tables.

To maintain the original functionality, I have also added support for both a single string schema and a list of string schemas as input parameters.
