### PR TITLE
Fix Primary key discovery query

### DIFF
--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -123,18 +123,20 @@ def discover_catalog(conn, db_name, db_schemas):
     pk_specs = select_all(
         conn,
         f"""
-        SELECT kc.table_name, kc.column_name
-        FROM information_schema.table_constraints tc
-        JOIN information_schema.key_column_usage kc
-            ON kc.table_name = tc.table_name AND
-               kc.table_schema = tc.table_schema AND
-               kc.constraint_name = tc.constraint_name
-        WHERE tc.constraint_type = 'PRIMARY KEY' AND
-        tc.table_schema in {db_schemas}
+        SELECT
+          n.nspname AS schema_name,
+          c.relname AS table_name,
+          a.attname AS column_name
+        FROM
+          pg_catalog.pg_constraint AS con
+          JOIN pg_catalog.pg_class AS c ON c.oid = con.conrelid
+          JOIN pg_catalog.pg_attribute AS a ON a.attrelid = c.oid AND a.attnum = ANY(con.conkey)
+          JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
+        WHERE schema_name in {db_schemas} contype IN ('p')
         ORDER BY
-          tc.table_schema,
-          tc.table_name,
-          kc.ordinal_position
+          schema_name,
+          table_name,
+          a.attnum;
         """
     )
     entries = []

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -132,7 +132,7 @@ def discover_catalog(conn, db_name, db_schemas):
           JOIN pg_catalog.pg_class AS c ON c.oid = con.conrelid
           JOIN pg_catalog.pg_attribute AS a ON a.attrelid = c.oid AND a.attnum = ANY(con.conkey)
           JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
-        WHERE schema_name in {db_schemas} contype IN ('p')
+        WHERE schema_name in {db_schemas} AND contype IN ('p')
         ORDER BY
           schema_name,
           table_name,


### PR DESCRIPTION
Current implementation returns empty set. Redshift tables information_schema.table_constraints and information_schema.key_column_usage are empty. 