### PR TITLE
Ensure matching column and db names during discover

### DIFF
--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -114,7 +114,7 @@ def discover_catalog(conn, db_name, db_schemas):
             CASE WHEN c.is_nullable = '' THEN 'YES' ELSE c.is_nullable END AS is_nullable
             FROM SVV_ALL_TABLES t
             JOIN SVV_ALL_COLUMNS c
-            ON c.table_name = t.table_name AND c.schema_name = t.schema_name
+            ON c.table_name = t.table_name AND c.schema_name = t.schema_name AND c.database_name = t.database_name
             WHERE t.schema_name in {db_schemas} and t.database_name = '{db_name}'
             ORDER BY c.table_name, c.ordinal_position
         """


### PR DESCRIPTION
The prior query would grab extra columns if there were two identically-named tables and schemas in different databases with different columns.

This fixed query ensures we are always querying columns for only one database